### PR TITLE
Add initial audit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Named after the raccoon dog logo of GitLab. A tool for performing actions on Git
      * [Binaries](README.md#binaries)
      * [Via Go](README.md#via-go)
 * [Usage](README.md#usage)
+     * [Audit](README.md#audit)
 
 ## Installation
 
@@ -33,6 +34,7 @@ Usage:
   tanuki [command]
 
 Available Commands:
+  audit       Audit members, branches, hooks, deploy keys etc.
   help        Help about any command
   version     Print the version number of Tanuki
 
@@ -45,4 +47,16 @@ Flags:
   -u, --url string      GitLab URL (default "https://gitlab.com/")
 
 Use "tanuki [command] --help" for more information about a command.
+```
+
+### Audit
+
+Audit members, branches, hooks, deploy keys etc.
+
+```console
+$ tanuki audit audit --token token --url https://gitlab.com/ --repository roaldnefs/tanuki
+roaldnefs / tanuki ->
+	Visibility: public
+	Merge Method: merge
+--
 ```

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -3,13 +3,26 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
-	"errors"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/xanzy/go-gitlab"
+)
+
+// List of patched available access levels.
+// Should be removed once github.com/xanzy/go-gitlab/pull/486 is merged.
+const (
+	NoPermissions         gitlab.AccessLevelValue = 0
+	GuestPermissions      gitlab.AccessLevelValue = 10
+	ReporterPermissions   gitlab.AccessLevelValue = 20
+	DeveloperPermissions  gitlab.AccessLevelValue = 30
+	MaintainerPermissions gitlab.AccessLevelValue = 40
+	OwnerPermissions      gitlab.AccessLevelValue = 50
 )
 
 var repository string
@@ -18,7 +31,7 @@ var repository string
 var auditCmd = &cobra.Command{
 	Use:   "audit",
 	Short: "Audit members, branches, hooks, deploy keys etc.",
-	Long: `Audit members, branches, hooks, deploy keys etc.`,
+	Long:  `Audit members, branches, hooks, deploy keys etc.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := newClient()
 		handleAudit(client, repository)
@@ -28,15 +41,7 @@ var auditCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(auditCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// auditCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// auditCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// Flags and configuration settings.
 	auditCmd.Flags().StringVarP(&repository, "repository", "r", "", "specific repo (e.g. 'roaldnefs/tanuki')")
 	auditCmd.MarkFlagRequired("repository")
 }
@@ -57,12 +62,33 @@ func handleAudit(client *gitlab.Client, repository string) error {
 	output := fmt.Sprintf("%s -> \n", project.NameWithNamespace)
 
 	if len(members) >= 1 {
-		projectMembers := []string{}
+		owners := []string{}
+		maintainers := []string{}
+		developers := []string{}
+		reporters := []string{}
+		guests := []string{}
+
 		for _, m := range members {
-			projectMembers = append(projectMembers, fmt.Sprintf("\t\t\t%s", m.Username))
+			switch m.AccessLevel {
+			case OwnerPermissions:
+				owners = append(owners, fmt.Sprintf("\t\t\t%s", m.Username))
+			case MaintainerPermissions:
+				maintainers = append(maintainers, fmt.Sprintf("\t\t\t%s", m.Username))
+			case DeveloperPermissions:
+				developers = append(developers, fmt.Sprintf("\t\t\t%s", m.Username))
+			case ReporterPermissions:
+				reporters = append(reporters, fmt.Sprintf("\t\t\t%s", m.Username))
+			case GuestPermissions:
+				guests = append(guests, fmt.Sprintf("\t\t\t%s", m.Username))
+			}
 		}
+
 		output += fmt.Sprintf("\tMembers (%d):\n", len(members))
-		output += fmt.Sprintf("\t\tRole (%d):\n%s\n", len(projectMembers), strings.Join(projectMembers, "\n"))
+		output += fmt.Sprintf("\t\tOwner (%d):\n%s\n", len(owners), strings.Join(owners, "\n"))
+		output += fmt.Sprintf("\t\tMaintainer (%d):\n%s\n", len(maintainers), strings.Join(maintainers, "\n"))
+		output += fmt.Sprintf("\t\tDeveloper (%d):\n%s\n", len(developers), strings.Join(developers, "\n"))
+		output += fmt.Sprintf("\t\tReporter (%d):\n%s\n", len(reporters), strings.Join(reporters, "\n"))
+		output += fmt.Sprintf("\t\tGuest (%d):\n%s\n", len(guests), strings.Join(guests, "\n"))
 	}
 
 	visibility := fmt.Sprintf("\tVisibility: %s", project.Visibility)
@@ -88,7 +114,11 @@ func getAllProjectMembers(client *gitlab.Client, pid interface{}) ([]*gitlab.Pro
 
 	for {
 		// Get the current page with members.
-		m, resp, err := client.ProjectMembers.ListAllProjectMembers(pid, opt)
+		//
+		// TODO Should be replaced by github.com/xanzy/go-gitlab/pull/485 the
+		// following code once merged:
+		// m, resp, err := client.ProjectMembers.ListAllProjectMembers(pid, opt)
+		m, resp, err := ListAllProjectMembers(client, pid, opt)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -143,5 +173,46 @@ func getProject(client *gitlab.Client, repository string) (*gitlab.Project, erro
 		opt.Page = resp.NextPage
 	}
 
-	return nil, errors.New(fmt.Sprintf("Project %s not found!", repository))
+	return nil, errors.New(fmt.Errorf("project %s not found", repository))
+}
+
+// Helper function to accept and format both the project ID or name as project
+// identifier for all API calls.
+//
+// TODO Should be removed once github.com/xanzy/go-gitlab/pull/485 is merged.
+func parseID(id interface{}) (string, error) {
+	switch v := id.(type) {
+	case int:
+		return strconv.Itoa(v), nil
+	case string:
+		return v, nil
+	default:
+		return "", fmt.Errorf("invalid ID type %#v, the ID must be an int or a string", id)
+	}
+}
+
+// ListAllProjectMembers gets a list of a project's team members viewable by the
+// authenticated user. Returns a list including inherited members through
+// ancestor groups.
+//
+// TODO Should be removed once github.com/xanzy/go-gitlab/pull/485 is merged.
+func ListAllProjectMembers(client *gitlab.Client, pid interface{}, opt *gitlab.ListProjectMembersOptions, options ...gitlab.OptionFunc) ([]*gitlab.ProjectMember, *gitlab.Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/members/all", url.QueryEscape(project))
+
+	req, err := client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var pm []*gitlab.ProjectMember
+	resp, err := client.Do(req, &pm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pm, resp, err
 }

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -1,0 +1,100 @@
+// Copyright © 2018 Roald Nefs <info@roaldnefs.com>
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"errors"
+
+	"github.com/spf13/cobra"
+	"github.com/xanzy/go-gitlab"
+)
+
+var repository string
+
+// auditCmd represents the audit command
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Audit members, branches, hooks, deploy keys etc.",
+	Long: `Audit members, branches, hooks, deploy keys etc.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := newClient()
+		handleAudit(client, repository)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(auditCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// auditCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// auditCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	auditCmd.Flags().StringVarP(&repository, "repository", "r", "", "specific repo (e.g. 'roaldnefs/tanuki')")
+	auditCmd.MarkFlagRequired("repository")
+}
+
+// handleAudit will return nil error if the user does not habe access to
+// something.
+func handleAudit(client *gitlab.Client, repository string) error {
+	project, err := getProject(client, repository)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	output := fmt.Sprintf("%s -> \n", project.NameWithNamespace)
+
+	visibility := fmt.Sprintf("\tVisibility: %s", project.Visibility)
+	output += visibility + "\n"
+
+	mergeMethod := fmt.Sprintf("\tMerge Method: %s", project.MergeMethod)
+	output += mergeMethod + "\n"
+
+	fmt.Printf("%s--\n\n", output)
+
+	return nil
+}
+
+// getProject returns the GitLab project based on the repository name by looping
+// over all the projects.
+func getProject(client *gitlab.Client, repository string) (*gitlab.Project, error) {
+	opt := &gitlab.ListProjectsOptions{
+		ListOptions: gitlab.ListOptions{
+			PerPage: 10,
+			Page:    1,
+		},
+	}
+
+	for {
+		// Get the current page with projects.
+		projects, resp, err := client.Projects.ListProjects(opt)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// List all the projects we've found so far.
+		for _, p := range projects {
+			// Return the project if the PathWithNamespace equals the repository
+			// string.
+			if p.PathWithNamespace == repository {
+				return p, nil
+			}
+		}
+
+		// Exit loop when we've seen all the pages.
+		if opt.Page >= resp.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		opt.Page = resp.NextPage
+	}
+
+	return nil, errors.New(fmt.Sprintf("Project %s not found!", repository))
+}

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -173,7 +173,7 @@ func getProject(client *gitlab.Client, repository string) (*gitlab.Project, erro
 		opt.Page = resp.NextPage
 	}
 
-	return nil, errors.New(fmt.Errorf("project %s not found", repository))
+	return nil, errors.New("requested repository not found")
 }
 
 // Helper function to accept and format both the project ID or name as project

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,9 +21,6 @@ var (
 	cfgFile, token, baseURL   string
 	enableDryRun, enableDebug bool
 
-	// git represent the GitLab API client.
-	git *gitlab.Client
-
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
 		Use:   "tanuki",
@@ -55,15 +52,11 @@ func init() {
 	rootCmd.MarkFlagRequired("token")
 	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
 
-	// Base URL for APU requests. Defaults to the public GitLab API, but can be
+	// Base URL for API requests. Defaults to the public GitLab API, but can be
 	// set to a domain endpoint to use with a self hosted GitLab Server. baseURL
 	// should always be specified with a trailing slash.
 	rootCmd.PersistentFlags().StringVarP(&baseURL, "url", "u", defaultBaseURL, "GitLab URL")
 	viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("url"))
-
-	// Initialize the GitLab client.
-	git = gitlab.NewClient(nil, token)
-	git.SetBaseURL(baseURL)
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -90,4 +83,11 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
+}
+
+// newClient returns a GitLab client.
+func newClient() *gitlab.Client {
+	client := gitlab.NewClient(nil, token)
+	client.SetBaseURL(baseURL)
+	return client
 }


### PR DESCRIPTION
Add initial audit command to audit members, branches, hooks, deploy
keys etc. of a specific project.